### PR TITLE
Disable the Slack integration for a while

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,29 @@
-require('./src/App').start()
+const Parser = require('./src/Parser')
+const GitHubApiClient = require("./src/GitHubApiClient")
+const PullRequests = require('./src/PullRequests')
+
+if (!process.env.GITHUB_AUTH_TOKEN) {
+  console.error('Error: GITHUB_AUTH_TOKEN is missing.')
+  return
+}
+
+const params = process.argv[2]
+
+if (!params) {
+  console.error('Error: pull request query parameters are missing.')
+  return
+}
+
+const conditions = new Parser(params).parse()
+const client = new GitHubApiClient()
+
+client.getAllPullRequests(conditions).then((pulls) => {
+  console.log('\nPull requests:')
+  pulls.forEach(p => console.log(p))
+
+  console.log('\nSlack messages:')
+  const messages = new PullRequests(pulls, conditions).convertToSlackMessages()
+  messages.forEach(m => console.log(m))
+
+  console.log('\n')
+})


### PR DESCRIPTION
So, now what we need to do is to export a new personal Github token as the `GITHUB_AUTH_TOKEN` env variable and run the following command:

```
node index.js "author:pempel repo:carnivalmobile/carnival-frontend,carnivalmobile/carnival-web-api"
```

Then we should get the following output:

```

Pull requests:
{ title: 'Upgrade Node.js to 10.19.0',
  url: 'https://github.com/carnivalmobile/carnival-frontend/pull/2413',
  author: { login: 'pempel' },
  createdAt: '2020-02-18T21:00:15Z',
  labels: { nodes: [] },
  reviewRequests: { nodes: [ [Object], [Object] ] },
  assignees: { nodes: [] } }

Slack messages:
1. `Upgrade Node.js to 10.19.0` https://github.com/carnivalmobile/carnival-frontend/pull/2413 by pempel (reviewer: j-stokes, raspygold) 7 days ago

```